### PR TITLE
Allow numbers in modbus register name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,146 @@
+*.o
+
+.vagrant/
+
+# meson files under development
+untitled.meson.build
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+*.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-12-17
+### Added
+- Modbus register name defines can contain numbers
+- `.gitignore` file added with default python ignores
+
+### Changed
+- Set register description to `""` if no description is provided in input
+  modbus register header file
+- Set semver informations to `0.1.0` in case no semver version could be parsed
+
 ## [0.8.0] - 2021-10-04
 ### Added
 - Holding registers and coils can be set via functions or based on input JSON
@@ -120,8 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - requirements file with all used python packages
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/python-modules/compare/0.8.0...develop
+[Unreleased]: https://github.com/brainelectronics/python-modules/compare/0.9.0...develop
 
+[0.9.0]: https://github.com/brainelectronics/python-modules/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/brainelectronics/python-modules/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/brainelectronics/python-modules/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/brainelectronics/python-modules/compare/0.5.0...0.6.0

--- a/generate_modbus_json.py
+++ b/generate_modbus_json.py
@@ -5,7 +5,7 @@
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         generate_modbus_json.py
 #  @date         December, 2021
-#  @version      0.3.2
+#  @version      0.4.0
 #  @brief        Generate a JSON file from a modbus register header file
 #
 #  @note         No numbers are allowed in the register name
@@ -39,7 +39,7 @@
 __author__ = "Jonas Scharpf"
 __copyright__ = "Copyright by brainelectronics, ALL RIGHTS RESERVED"
 __credits__ = ["Jonas Scharpf"]
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __maintainer__ = "Jonas Scharpf"
 __email__ = "info@brainelectronics.de"
 __status__ = "Development"
@@ -182,11 +182,13 @@ def extract_defined_registers(file_path: str, logger: logging.Logger) -> dict:
         # take only line of register definiton
         if line.startswith('#define '):
             # get the register name which must be given in capital letters and
-            # must be more or equal to 3 characters
-            register_name = re.findall(r'[A-Z_]{3,}', line)[0]
+            # must be more or equal to 3 characters, maybe with numbers in it
+            register_name = re.findall(r'[A-Z_0-9]{3,}', line)[0]
 
+            # get the part without the register name
+            tmp_part = line.split(register_name)[-1]
             # get the first number with any length, which shall be the register
-            register_register = re.findall(r'\d+', line)[0]
+            register_register = re.findall(r'\d+', tmp_part)[0]
 
             # loop over all additional registers if any available in the next
             # line

--- a/generate_modbus_json.py
+++ b/generate_modbus_json.py
@@ -4,8 +4,8 @@
 #
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         generate_modbus_json.py
-#  @date         July, 2021
-#  @version      0.3.1
+#  @date         December, 2021
+#  @version      0.3.2
 #  @brief        Generate a JSON file from a modbus register header file
 #
 #  @note         No numbers are allowed in the register name
@@ -201,7 +201,10 @@ def extract_defined_registers(file_path: str, logger: logging.Logger) -> dict:
                 i -= 1
 
             # get the description of that register after the doxygen comment
-            register_description = line.split('//< ')[1]
+            try:
+                register_description = line.split('//<')[1].lstrip()
+            except IndexError:
+                register_description = ''
 
             # try to get unit of register description provided as '[something]'
             register_unit_list = re.findall(r'\[(.*?)\]', register_description)

--- a/generate_vcs.py
+++ b/generate_vcs.py
@@ -4,8 +4,8 @@
 #
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         generate_vcs.py
-#  @date         July, 2021
-#  @version      0.3.1
+#  @date         December, 2021
+#  @version      0.3.2
 #  @brief        Generate vcs info file based on available Git informations
 #
 #  @usage
@@ -41,7 +41,7 @@
 __author__ = "Jonas Scharpf"
 __copyright__ = "Copyright by brainelectronics, ALL RIGHTS RESERVED"
 __credits__ = ["Jonas Scharpf"]
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __maintainer__ = "Jonas Scharpf"
 __email__ = "jonas@brainelectronics.de"
 __status__ = "Beta"
@@ -50,6 +50,7 @@ import argparse
 import datetime
 import json
 import logging
+from collections import namedtuple
 from pathlib import Path
 import semver
 import sys
@@ -161,19 +162,21 @@ def parse_semver(tag: str,
     try:
         ver = semver.VersionInfo.parse(tag)
         logger.debug('SemVer tag: {}'.format(ver))
-
-        # major, minor, patch, prerelease
-        semver_dict['major_{}version'.format(identifier)] = ver.major
-        semver_dict['minor_{}version'.format(identifier)] = ver.minor
-        semver_dict['patch_{}version'.format(identifier)] = ver.patch
-        semver_dict['prerelease_{}version'.format(identifier)] = ver.prerelease
-        semver_dict['build_{}version'.format(identifier)] = ver.build
-
-        logger.debug('SemVer dict: {}'.format(json.dumps(semver_dict,
-                                                         indent=4,
-                                                         sort_keys=True)))
     except Exception as e:
         logger.warning(e)
+        VersionInfo = namedtuple('VersionInfo', ["major", "minor", "patch", "prerelease", "build"], defaults=(0, 1, 0, None, None))
+        ver = VersionInfo()
+
+    # major, minor, patch, prerelease
+    semver_dict['major_{}version'.format(identifier)] = ver.major
+    semver_dict['minor_{}version'.format(identifier)] = ver.minor
+    semver_dict['patch_{}version'.format(identifier)] = ver.patch
+    semver_dict['prerelease_{}version'.format(identifier)] = ver.prerelease
+    semver_dict['build_{}version'.format(identifier)] = ver.build
+
+    logger.debug('SemVer dict: {}'.format(json.dumps(semver_dict,
+                                                     indent=4,
+                                                     sort_keys=True)))
 
     return semver_dict
 

--- a/git_wrapper/git_wrapper.py
+++ b/git_wrapper/git_wrapper.py
@@ -252,7 +252,10 @@ class GitWrapper(ModuleHelper):
         this_repo = self.get_valid_repo(repo=repo)
 
         if this_repo is not None:
-            available_ref = this_repo.git.describe()
+            try:
+                available_ref = this_repo.git.describe()
+            except Exception as e:
+                self.logger.warning(e)
 
         return available_ref
 


### PR DESCRIPTION
### Added
- Modbus register name defines can contain numbers
- `.gitignore` file added with default python ignores

### Changed
- Set register description to `""` if no description is provided in input modbus register header file
- Set semver informations to `0.1.0` in case no semver version could be parsed
