### PR TITLE
Improve modbus wrapper abstraction

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
+per-file-ignores = __init__.py:F401
+
 exclude =
     .git,
     .venv,

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ python3 write_device_info_registers.py \
 --port=180 \
 --print \
 --pretty \
--v4 -d
+--debug \
+--verbose=4
 ```
 
 ##### Modbus RTU
@@ -259,7 +260,8 @@ python3 write_device_info_registers.py \
 --baudrate=19200 \
 --print \
 --pretty \
--v4 -d
+--debug \
+--verbose=4
 ```
 
 ### Structure info generator
@@ -274,7 +276,7 @@ sorted style. An example output can be found at
 
 ```bash
 python generate_structure_info.py \
---root ./ \
+--root=./ \
 --print \
 --pretty \
 --save \

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-01-11
+### Added
+- First breaking change since 9 releases :)
+- Provide property for latest read register data, bus ID unit, client and
+   connection in `ModbusWrapper` class
+- Connection to device can be setup once with `setup_connection` function
+- Connection status can be set with `connect` and checked with `connection`
+  property
+
+### Changed
+- `read_all_registers` and `write_all_registers` require setup and opened
+  connection beforehand
+- All register operation functions use setup connection and unit instead of
+  function call arguments for client and unit
+- Import level decreased by adjusting content of module `__init__.py` file
+- `F401` is ignored for all `__init__.py` files
+
+### Fixed
+- Shebang of `log_modbus_to_database.py`, `read_device_info_registers.py` and
+  `write_device_info_registers.py` is `python3` instead of unspecific `python`
+- Yet another set of flake8 warnings removed
+
 ## [0.9.0] - 2021-12-17
 ### Added
 - Modbus register name defines can contain numbers
@@ -130,8 +152,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - requirements file with all used python packages
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/python-modules/compare/0.9.0...develop
+[Unreleased]: https://github.com/brainelectronics/python-modules/compare/1.0.0...develop
 
+[1.0.0]: https://github.com/brainelectronics/python-modules/compare/0.9.0...1.0.0
 [0.9.0]: https://github.com/brainelectronics/python-modules/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/brainelectronics/python-modules/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/brainelectronics/python-modules/compare/0.6.0...0.7.0

--- a/compilation_info_generator/__init__.py
+++ b/compilation_info_generator/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .compilation_info_generator import CompilationInfoGenerator

--- a/compilation_info_generator/compilation_info_generator.py
+++ b/compilation_info_generator/compilation_info_generator.py
@@ -12,8 +12,8 @@ import os
 from pathlib import Path
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
-from git_wrapper.git_wrapper import GitWrapper
+from module_helper import ModuleHelper
+from git_wrapper import GitWrapper
 
 
 class CompilationInfoGenerator(GitWrapper, ModuleHelper):

--- a/db_wrapper/__init__.py
+++ b/db_wrapper/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .sqlite_wrapper import SQLiteWrapper

--- a/db_wrapper/sqlite_wrapper.py
+++ b/db_wrapper/sqlite_wrapper.py
@@ -14,7 +14,7 @@ import sqlite3
 from typing import List
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
+from module_helper import ModuleHelper
 
 
 class SQLiteWrapper(ModuleHelper):
@@ -25,9 +25,6 @@ class SQLiteWrapper(ModuleHelper):
             logger = self.create_logger()
         self.logger = logger
         self.logger.disabled = quiet
-
-        self.repo = None
-        self.git_dict = dict()
 
         self.logger.debug('SQLiteWrapper init finished')
 

--- a/generate_compilation_info.py
+++ b/generate_compilation_info.py
@@ -49,33 +49,8 @@ import argparse
 import json
 
 # custom imports
-from compilation_info_generator.compilation_info_generator \
-    import CompilationInfoGenerator
-from module_helper.module_helper import ModuleHelper
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            pass
-            # do not increment here, so '-v' will use highest log level
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                # self.values = values.count('v')+1
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from compilation_info_generator import CompilationInfoGenerator
+from module_helper import ModuleHelper, VAction
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/generate_modbus_json.py
+++ b/generate_modbus_json.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
-# ----------------------------------------------------------------------------
+"""Generate a JSON file from a modbus register header file"""
 #
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         generate_modbus_json.py
@@ -51,30 +51,7 @@ from pathlib import Path
 import re
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            pass
-            # do not increment here, so '-v' will use highest log level
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from module_helper import ModuleHelper, VAction
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/generate_structure_info.py
+++ b/generate_structure_info.py
@@ -8,8 +8,6 @@
 #  @version      0.2.1
 #  @brief        Generate structure information data JSON file
 #
-#  This script ...
-#
 #  @usage
 #  python generate_structure_info.py \
 #   --root path-to-root-of-structure \
@@ -47,32 +45,8 @@ import argparse
 import json
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
-from structure_info_generator.structure_info_generator \
-    import StructureInfoGenerator
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            pass
-            # do not increment here, so '-v' will use highest log level
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from module_helper import ModuleHelper, VAction
+from structure_info_generator import StructureInfoGenerator
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/generate_vcs.py
+++ b/generate_vcs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
-# ----------------------------------------------------------------------------
+"""Generate vcs info file based on available Git informations"""
 #
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         generate_vcs.py
@@ -56,31 +56,8 @@ import semver
 import sys
 
 # custom imports
-from git_wrapper.git_wrapper import GitWrapper
-from module_helper.module_helper import ModuleHelper
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            pass
-            # do not increment here, so '-v' will use highest log level
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from git_wrapper import GitWrapper
+from module_helper import ModuleHelper, VAction
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -164,7 +141,11 @@ def parse_semver(tag: str,
         logger.debug('SemVer tag: {}'.format(ver))
     except Exception as e:
         logger.warning(e)
-        VersionInfo = namedtuple('VersionInfo', ["major", "minor", "patch", "prerelease", "build"], defaults=(0, 1, 0, None, None))
+        VersionInfo = namedtuple('VersionInfo',
+                                 field_names=[
+                                    "major", "minor", "patch", "prerelease",
+                                    "build"],
+                                 defaults=(0, 1, 0, None, None))
         ver = VersionInfo()
 
     # major, minor, patch, prerelease

--- a/git_wrapper/__init__.py
+++ b/git_wrapper/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .git_wrapper import GitWrapper

--- a/git_wrapper/git_wrapper.py
+++ b/git_wrapper/git_wrapper.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import List
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
+from module_helper import ModuleHelper
 
 
 class GitWrapper(ModuleHelper):

--- a/log_modbus_to_database.py
+++ b/log_modbus_to_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 """Log read Modbus device register informations to database"""
 #
@@ -79,32 +79,9 @@ import sqlite3
 from typing import Tuple
 
 # custom imports
-from db_wrapper.sqlite_wrapper import SQLiteWrapper
-from modbus_wrapper.modbus_wrapper import ModbusWrapper
-from module_helper.module_helper import ModuleHelper
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            pass
-            # do not increment here, so '-v' will use highest log level
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from db_wrapper import SQLiteWrapper
+from modbus_wrapper import ModbusWrapper
+from module_helper import ModuleHelper, VAction
 
 
 def generate_columns_names(registers: dict,

--- a/modbus_wrapper/__init__.py
+++ b/modbus_wrapper/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .modbus_wrapper import ModbusWrapper

--- a/module_helper/__init__.py
+++ b/module_helper/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .module_helper import ModuleHelper, VAction

--- a/module_helper/module_helper.py
+++ b/module_helper/module_helper.py
@@ -20,6 +20,11 @@ from typing import List
 import yaml
 
 
+class ModuleHelperError(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+
 class ModuleHelper(object):
     """docstring for ModuleHelper"""
     def __init__(self, logger: logging.Logger = None, quiet: bool = False):
@@ -29,7 +34,8 @@ class ModuleHelper(object):
         self.logger = logger
         self.logger.disabled = quiet
 
-    def create_logger(self, logger_name: str = None) -> logging.Logger:
+    @staticmethod
+    def create_logger(logger_name: str = None) -> logging.Logger:
         """
         Create a logger.
 
@@ -57,10 +63,10 @@ class ModuleHelper(object):
 
         return logger
 
-    def set_logger_verbose_level(self,
-                                 logger: logging.Logger,
+    @staticmethod
+    def set_logger_verbose_level(logger: logging.Logger,
                                  verbose_level: int,
-                                 debug_output: bool):
+                                 debug_output: bool) -> None:
         """
         Set the logger verbose level and debug output
 
@@ -103,12 +109,13 @@ class ModuleHelper(object):
             if option not in ele:
                 result.append(option)
             else:
-                self.logger.info('{} is not a valid option'.format(option))
+                raise ModuleHelperError('{} is not a valid option of {}'.
+                                        format(option, options))
 
         return result
 
-    def check_option_values(self,
-                            options: List[str],
+    @staticmethod
+    def check_option_values(options: List[str],
                             option: str,
                             raise_error: bool = False) -> bool:
         """
@@ -135,7 +142,8 @@ class ModuleHelper(object):
 
         return result
 
-    def format_timestamp(self, timestamp: int, format: str) -> str:
+    @staticmethod
+    def format_timestamp(timestamp: int, format: str) -> str:
         """
         Get timestamp as string in specified format
 
@@ -149,7 +157,8 @@ class ModuleHelper(object):
         """
         return datetime.fromtimestamp(timestamp).strftime(format)
 
-    def get_unix_timestamp(self) -> int:
+    @staticmethod
+    def get_unix_timestamp() -> int:
         """
         Get the unix timestamp.
 
@@ -158,7 +167,8 @@ class ModuleHelper(object):
         """
         return (int(time.time()))
 
-    def get_random_string(self, length: int) -> str:
+    @staticmethod
+    def get_random_string(length: int) -> str:
         """
         Get a random string with characters and numbers.
 
@@ -171,7 +181,8 @@ class ModuleHelper(object):
         return ''.join(random.choices(string.ascii_uppercase + string.digits,
                                       k=length))
 
-    def convert_string_to_uint16t(self, content: str) -> list:
+    @staticmethod
+    def convert_string_to_uint16t(content: str) -> list:
         """
         Convert string to list of uint16_t values
 
@@ -183,7 +194,7 @@ class ModuleHelper(object):
         """
         # convert all characters to their unicode code, 'A' -> 65 ...
         unicode_list = [ord(x) for x in content]
-        self.logger.debug('Content as unicode: {}'.format(unicode_list))
+        # self.logger.debug('Content as unicode: {}'.format(unicode_list))
 
         # iter the list and create tuples
         # represented by 8 bit, two unicode chars can be represented by 16 bit
@@ -195,11 +206,12 @@ class ModuleHelper(object):
         for ele in tuple_list:
             number_list.append((ele[0] << 8) | ele[1])
 
-        self.logger.debug('Content as numbers: {}'.format(number_list))
+        # self.logger.debug('Content as numbers: {}'.format(number_list))
 
         return number_list
 
-    def sort_by_name(self, a_list: list, descending: bool = False) -> bool:
+    @staticmethod
+    def sort_by_name(a_list: list, descending: bool = False) -> bool:
         """
         Sort list by name.
 
@@ -223,7 +235,8 @@ class ModuleHelper(object):
 
         return result
 
-    def is_json(self, content: dict) -> bool:
+    @staticmethod
+    def is_json(content: dict) -> bool:
         """
         Determine whether the specified content is json.
 
@@ -245,10 +258,8 @@ class ModuleHelper(object):
 
         return True
 
-    @classmethod
-    def parser_valid_file(cls,
-                          parser: argparse.ArgumentParser,
-                          arg: str) -> str:
+    @staticmethod
+    def parser_valid_file(parser: argparse.ArgumentParser, arg: str) -> str:
         """
         Determine whether file exists.
 
@@ -266,10 +277,8 @@ class ModuleHelper(object):
         else:
             return arg
 
-    @classmethod
-    def parser_valid_dir(cls,
-                         parser: argparse.ArgumentParser,
-                         arg: str) -> str:
+    @staticmethod
+    def parser_valid_dir(parser: argparse.ArgumentParser, arg: str) -> str:
         """
         Determine whether directory exists.
 
@@ -287,8 +296,8 @@ class ModuleHelper(object):
         else:
             return arg
 
-    @classmethod
-    def check_file(cls, file_path: str, suffix: str) -> bool:
+    @staticmethod
+    def check_file(file_path: str, suffix: str) -> bool:
         """
         Check existance and type of file
 
@@ -309,8 +318,8 @@ class ModuleHelper(object):
 
         return result
 
-    @classmethod
-    def check_folder(cls, folder_path: str) -> bool:
+    @staticmethod
+    def check_folder(folder_path: str) -> bool:
         """
         Check existance of folder
 
@@ -326,6 +335,29 @@ class ModuleHelper(object):
             result = True
 
         return result
+
+    @staticmethod
+    def get_current_path() -> Path:
+        """
+        Get the full path to this file.
+
+        :returns:   The path of this file
+        :rtype:     Path object
+        """
+        return ModuleHelper.get_full_path(base=__file__)
+
+    @staticmethod
+    def get_full_path(base: str) -> Path:
+        """
+        Return full path to parent of path
+
+        :param      base:  The base
+        :type       base:  str
+
+        :returns:   The full path.
+        :rtype:     Path
+        """
+        return Path(base).parent.resolve()
 
     def save_yaml_file(self, path: str, content: dict) -> bool:
         """

--- a/module_helper/module_helper.py
+++ b/module_helper/module_helper.py
@@ -659,3 +659,26 @@ class ModuleHelper(object):
             self.logger.warning('Failed to save content to file: {}'.format(e))
 
         return result
+
+
+class VAction(argparse.Action):
+    """docstring for VAction"""
+    def __init__(self, option_strings, dest, nargs=None, const=None,
+                 default=None, type=None, choices=None, required=False,
+                 help=None, metavar=None):
+        super(VAction, self).__init__(option_strings, dest, nargs, const,
+                                      default, type, choices, required,
+                                      help, metavar)
+        self.values = 0
+
+    def __call__(self, parser, args, values, option_string=None):
+        """Actual call or action to perform"""
+        if values is None:
+            # do not increment here, so '-v' will use highest log level
+            pass
+        else:
+            try:
+                self.values = int(values)
+            except ValueError:
+                self.values = values.count('v')  # do not count the first '-v'
+        setattr(args, self.dest, self.values)

--- a/read_device_info_registers.py
+++ b/read_device_info_registers.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 """Read Modbus device register informations based on JSON registers file"""
 #
 #  @author       Jonas Scharpf (info@brainelectronics.de) brainelectronics
 #  @file         read_device_info_registers.py
-#  @date         July, 2021
-#  @version      0.4.0
+#  @date         December, 2021
+#  @version      0.5.0
 #  @brief        Read all registers via RTU modbus or external IP
 #
 #  @required     pymodbus 2.3.0 or higher
@@ -70,31 +70,8 @@ import argparse
 import json
 
 # custom imports
-from modbus_wrapper.modbus_wrapper import ModbusWrapper
-from module_helper.module_helper import ModuleHelper
-
-
-class VAction(argparse.Action):
-    """docstring for VAction"""
-    def __init__(self, option_strings, dest, nargs=None, const=None,
-                 default=None, type=None, choices=None, required=False,
-                 help=None, metavar=None):
-        super(VAction, self).__init__(option_strings, dest, nargs, const,
-                                      default, type, choices, required,
-                                      help, metavar)
-        self.values = 0
-
-    def __call__(self, parser, args, values, option_string=None):
-        """Actual call or action to perform"""
-        if values is None:
-            # do not increment here, so '-v' will use highest log level
-            pass
-        else:
-            try:
-                self.values = int(values)
-            except ValueError:
-                self.values = values.count('v')  # do not count the first '-v'
-        setattr(args, self.dest, self.values)
+from modbus_wrapper import ModbusWrapper
+from module_helper import ModuleHelper, VAction
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -228,13 +205,26 @@ if __name__ == "__main__":
     # create objects
     mb = ModbusWrapper(logger=register_logger, quiet=not args.debug)
 
+    # open connection to device
+    result = mb.setup_connection(device_type=args.connection,
+                                 address=args.address,
+                                 port=port,
+                                 unit=unit,
+                                 baudrate=baudrate)
+    if result is False:
+        logger.error('Failed to setup connection with {device_type} device '
+                     'with bus ID {unit} at {address}:{port}'.
+                     format(device_type=args.connection,
+                            unit=unit,
+                            address=args.address,
+                            port=port))
+        exit(-1)
+
+    # open connection to device
+    mb.connect = True
+
     # create and get the info dict
-    read_content = mb.read_all_registers(device_type=args.connection,
-                                         address=args.address,
-                                         port=port,
-                                         unit=unit,
-                                         baudrate=baudrate,
-                                         check_expectation=args.validate,
+    read_content = mb.read_all_registers(check_expectation=args.validate,
                                          file=args.file)
 
     now = helper.get_unix_timestamp()

--- a/structure_info_generator/__init__.py
+++ b/structure_info_generator/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from .structure_info_generator import StructureInfoGenerator

--- a/structure_info_generator/structure_info_generator.py
+++ b/structure_info_generator/structure_info_generator.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 
 # custom imports
-from module_helper.module_helper import ModuleHelper
+from module_helper import ModuleHelper
 
 
 class StructureInfoGenerator(ModuleHelper):


### PR DESCRIPTION
### Added
- First breaking change since 9 releases :)
- Provide property for latest read register data, bus ID unit, client and
   connection in `ModbusWrapper` class
- Connection to device can be setup once with `setup_connection` function
- Connection status can be set with `connect` and checked with `connection`
  property

### Changed
- `read_all_registers` and `write_all_registers` require setup and opened
  connection beforehand
- All register operation functions use setup connection and unit instead of
  function call arguments for client and unit
- Import level decreased by adjusting content of module `__init__.py` file
- `F401` is ignored for all `__init__.py` files

### Fixed
- Shebang of `log_modbus_to_database.py`, `read_device_info_registers.py` and
  `write_device_info_registers.py` is `python3` instead of unspecific `python`
- Yet another set of flake8 warnings removed
